### PR TITLE
Fixing ZeroDivisionError Error for some MusicXML files

### DIFF
--- a/tokenization_tools/tokenizer/score_to_tokens.py
+++ b/tokenization_tools/tokenizer/score_to_tokens.py
@@ -189,7 +189,10 @@ def measures_to_tokens(measures, soup, staff=None, note_name=True):
                     tokens += attr_tokens
                     divisions = div if div else divisions
                 elif element.name == 'note':
-                    tokens += note_to_tokens(element, divisions, note_name)
+                    if divisions == 0:
+                        tokens += note_to_tokens(element, note_name)
+                    else:
+                        tokens += note_to_tokens(element, divisions, note_name)
 
             if voice_elements:
                 for voice in voices:
@@ -201,7 +204,10 @@ def measures_to_tokens(measures, soup, staff=None, note_name=True):
                                 tokens += attr_tokens
                                 divisions = div if div else divisions
                             elif element.name == 'note':
-                                tokens += note_to_tokens(element, divisions, note_name)
+                                if divisions == 0:
+                                    tokens += note_to_tokens(element, note_name)
+                                else:
+                                    tokens += note_to_tokens(element, divisions, note_name)
                     tokens.append('</voice>')
 
             for element in post_voice_elements:
@@ -221,7 +227,10 @@ def measures_to_tokens(measures, soup, staff=None, note_name=True):
                     tokens += attr_tokens
                     divisions = div if div else divisions
                 elif element.name == 'note':
-                    tokens += note_to_tokens(element, divisions, note_name)
+                    if divisions == 0:
+                        tokens += note_to_tokens(element, note_name)
+                    else:
+                        tokens += note_to_tokens(element, divisions, note_name)
 
     return tokens
 

--- a/tokenization_tools/tokenizer/score_to_tokens.py
+++ b/tokenization_tools/tokenizer/score_to_tokens.py
@@ -216,7 +216,11 @@ def measures_to_tokens(measures, soup, staff=None, note_name=True):
                     tokens += attr_tokens
                     divisions = div if div else divisions
                 elif element.name == 'note':
-                    tokens += note_to_tokens(element, divisions, note_name)
+                    if divisions == 0:
+                        tokens += note_to_tokens(element, note_name)
+                    else:
+                        tokens += note_to_tokens(element, divisions, note_name)
+                        
         else:
             for element in measure.contents:
                 if staff is not None:


### PR DESCRIPTION
The MusicXML tokenisation fails on some files where the <attribute> tag is located below a <note> tag. An example is attached (in the file the note with id="n94" is located above the <backup> and <attributes> tag. This results in a ZeroDivisionError error as the divisions variable is assigned a value of 0, and a simple fix by using the default value of divisions (8) instead will circumvent this error, and is implemented here.

[Seg_2.zip](https://github.com/suzuqn/ScoreTransformer/files/13497453/Seg_2.zip)
